### PR TITLE
feat: setup destruction arena prototype

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  plugins: ['@typescript-eslint', 'prettier'],
+  rules: {
+    'prettier/prettier': 'error',
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,15 @@
 # Agents.md (Guia Vivo)
-
 Documento para **registrar decisões** e **orquestrar tarefas** futuras.
 Atualize sempre que implementar algo relevante.
 
 ## Regras importantes
-
 - Sempre verifique os testes se não quebraram.
 - Sempre crie testes para novas funcionalidades.
 - Ajuste os testes se necessário.
+
+## 2025-08-20 - Setup inicial do projeto
+- Estrutura base com Three.js e TypeScript.
+- Arquivos principais criados: Car, Arena, Physics e index.
+- Configuração de Vite, ESLint e Prettier.
+- Testes unitários básicos para lógica de vida do carro.
+- Próximos passos: adicionar upgrades, múltiplos bots e suporte a multiplayer com Socket.IO.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Car Destruction Arena
+
+Protótipo de jogo web em Three.js onde o objetivo é destruir os outros carros e ser o último sobrevivente. Este projeto está estruturado em TypeScript e preparado para evoluir para multiplayer online com Socket.IO.
+
+## Visão Geral
+- Arena 3D simples com Two carros: jogador e bot.
+- Física de colisão utilizando Cannon-es.
+- Barra de vida acima de cada carro.
+- Quando a vida chega a zero o carro é removido da arena.
+- Estrutura modular para futura expansão e suporte a multiplayer.
+
+## Tecnologias
+- [Three.js](https://threejs.org/)
+- [Cannon-es](https://github.com/pmndrs/cannon-es)
+- TypeScript
+- Node.js
+- Vite
+
+## Como rodar localmente
+1. Instale as dependências:
+   ```bash
+   npm install
+   ```
+2. Ambiente de desenvolvimento:
+   ```bash
+   npm run dev
+   ```
+3. Rodar testes:
+   ```bash
+   npm test
+   ```
+
+## Estrutura de Pastas
+```
+├─ src/          # código fonte
+├─ public/       # assets estáticos
+├─ tests/        # testes unitários
+├─ docs/         # documentação complementar
+```
+
+## Roadmap
+- [ ] Sistema de upgrades/modificações.
+- [ ] Múltiplos bots com IA melhorada.
+- [ ] Explosões visuais ao destruir carros.
+- [ ] Backend com Socket.IO e Redis para multiplayer.
+- [ ] Persistência de upgrades em banco de dados.
+- [ ] Containerização com Docker.
+
+## Licença
+Projeto criado para fins educativos.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Car Destruction Arena</title>
+  </head>
+  <body>
+    <script type="module" src="/src/index.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "games-car_destruction_web",
+  "version": "1.0.0",
+  "description": "Arena de destruição de carros em Three.js",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "build:ts": "tsc",
+    "test": "npm run build:ts && node --test dist/tests/*.js",
+    "lint": "eslint .",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "three": "^0.167.0",
+    "cannon-es": "^0.20.0",
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-legacy": "^5.0.0",
+    "@types/three": "^0.167.0",
+    "@types/node": "^20.0.0",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "prettier": "^3.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0"
+  }
+}

--- a/src/Arena.ts
+++ b/src/Arena.ts
@@ -1,0 +1,62 @@
+import * as THREE from 'three';
+import * as CANNON from 'cannon-es';
+
+/**
+ * Responsável por montar a arena básica de destruição.
+ */
+export default class Arena {
+  size: number;
+
+  constructor(scene: any, world: any, size = 50) {
+    this.size = size;
+
+    // Chão
+    const groundGeo = new THREE.PlaneGeometry(size, size);
+    const groundMat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+    const groundMesh = new THREE.Mesh(groundGeo, groundMat);
+    groundMesh.rotation.x = -Math.PI / 2;
+    scene.add(groundMesh);
+
+    const groundBody = new CANNON.Body({ mass: 0, shape: new CANNON.Plane() });
+    groundBody.quaternion.setFromEuler(-Math.PI / 2, 0, 0);
+    world.addBody(groundBody);
+
+    // Paredes
+    const half = size / 2;
+    const wallHeight = 5;
+    const wallThickness = 1;
+    const wallShape = new CANNON.Box(new CANNON.Vec3(half, wallHeight, wallThickness));
+    const wallMaterial = new THREE.MeshStandardMaterial({ color: 0x888888 });
+
+    const wallPositions = [
+      { x: 0, y: wallHeight / 2, z: -half },
+      { x: 0, y: wallHeight / 2, z: half },
+    ];
+    wallPositions.forEach((pos) => {
+      const wallGeo = new THREE.BoxGeometry(size, wallHeight, wallThickness * 2);
+      const wallMesh = new THREE.Mesh(wallGeo, wallMaterial);
+      wallMesh.position.set(pos.x, pos.y, pos.z);
+      scene.add(wallMesh);
+
+      const wallBody = new CANNON.Body({ mass: 0, shape: wallShape });
+      wallBody.position.set(pos.x, pos.y, pos.z);
+      world.addBody(wallBody);
+    });
+
+    const sideWallShape = new CANNON.Box(new CANNON.Vec3(wallThickness, wallHeight, half));
+    const sidePositions = [
+      { x: -half, y: wallHeight / 2, z: 0 },
+      { x: half, y: wallHeight / 2, z: 0 },
+    ];
+    sidePositions.forEach((pos) => {
+      const wallGeo = new THREE.BoxGeometry(wallThickness * 2, wallHeight, size);
+      const wallMesh = new THREE.Mesh(wallGeo, wallMaterial);
+      wallMesh.position.set(pos.x, pos.y, pos.z);
+      scene.add(wallMesh);
+
+      const wallBody = new CANNON.Body({ mass: 0, shape: sideWallShape });
+      wallBody.position.set(pos.x, pos.y, pos.z);
+      world.addBody(wallBody);
+    });
+  }
+}

--- a/src/Car.ts
+++ b/src/Car.ts
@@ -1,0 +1,43 @@
+/**
+ * Representa um carro dentro da arena.
+ * Responsável apenas pela lógica de vida do veículo.
+ * A renderização e física são tratadas em outros módulos.
+ */
+export default class Car {
+  id: string;
+  maxHealth: number;
+  health: number;
+
+  constructor(id: string, maxHealth = 100) {
+    this.id = id;
+    this.maxHealth = maxHealth;
+    this.health = maxHealth;
+  }
+
+  /**
+   * Aplica dano ao carro.
+   * @param amount Quantidade de dano recebido.
+   * @returns Vida restante após o dano.
+   */
+  applyDamage(amount: number): number {
+    this.health = Math.max(0, this.health - amount);
+    return this.health;
+  }
+
+  /**
+   * Verifica se o carro foi destruído.
+   */
+  isDestroyed(): boolean {
+    return this.health <= 0;
+  }
+
+  /**
+   * Restaura vida ao carro.
+   * @param amount Quantidade de vida recuperada.
+   * @returns Vida atual após a cura.
+   */
+  heal(amount: number): number {
+    this.health = Math.min(this.maxHealth, this.health + amount);
+    return this.health;
+  }
+}

--- a/src/Physics.ts
+++ b/src/Physics.ts
@@ -1,0 +1,22 @@
+import * as CANNON from 'cannon-es';
+
+/**
+ * Encapsula a configuração da física com Cannon-es.
+ */
+export default class Physics {
+  world: any;
+
+  constructor() {
+    this.world = new CANNON.World({ gravity: new CANNON.Vec3(0, -9.82, 0) });
+  }
+
+  /**
+   * Atualiza o mundo físico.
+   * @param delta Tempo em segundos desde o último frame.
+   */
+  step(delta: number): void {
+    const fixedTimeStep = 1 / 60;
+    const maxSubSteps = 3;
+    this.world.step(fixedTimeStep, delta, maxSubSteps);
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+declare module 'three';
+declare module 'cannon-es';
+declare module 'three/examples/jsm/controls/OrbitControls';
+declare module 'node:test';
+declare module 'node:assert';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,141 @@
+import * as THREE from 'three';
+import * as CANNON from 'cannon-es';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+import Car from './Car.js';
+import Arena from './Arena.js';
+import Physics from './Physics.js';
+
+// Cena principal
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+// Luzes
+const light = new THREE.DirectionalLight(0xffffff, 1);
+light.position.set(10, 10, 10);
+scene.add(light);
+scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+
+// Controles de câmera
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0, 0);
+camera.position.set(0, 20, 30);
+controls.update();
+
+// Física
+const physics = new Physics();
+new Arena(scene, physics.world);
+
+// Criação de carros
+interface CarEntity {
+  car: Car;
+  mesh: any;
+  body: any;
+  lifeBar: any;
+}
+
+function createCarEntity(id: string, color: number, position: any): CarEntity {
+  const car = new Car(id);
+  const geometry = new THREE.BoxGeometry(2, 1, 4);
+  const material = new THREE.MeshStandardMaterial({ color });
+  const mesh = new THREE.Mesh(geometry, material);
+  scene.add(mesh);
+
+  const shape = new CANNON.Box(new CANNON.Vec3(1, 0.5, 2));
+  const body = new CANNON.Body({ mass: 150 });
+  body.addShape(shape);
+  body.position.copy(position);
+  physics.world.addBody(body);
+
+  // Barra de vida simples
+  const barGeo = new THREE.PlaneGeometry(2, 0.2);
+  const barMat = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide });
+  const lifeBar = new THREE.Mesh(barGeo, barMat);
+  lifeBar.position.set(0, 1, 0);
+  mesh.add(lifeBar);
+
+  return { car, mesh, body, lifeBar };
+}
+
+const player = createCarEntity('player', 0x0000ff, new CANNON.Vec3(-5, 0.5, 0));
+const enemy = createCarEntity('enemy', 0xff0000, new CANNON.Vec3(5, 0.5, 0));
+
+// Controle do jogador
+const keys: Record<string, boolean> = {};
+document.addEventListener('keydown', (e) => (keys[e.key] = true));
+document.addEventListener('keyup', (e) => (keys[e.key] = false));
+
+function handlePlayerControl() {
+  const force = 200;
+  if (keys['ArrowUp']) player.body.applyForce(new CANNON.Vec3(0, 0, -force), player.body.position);
+  if (keys['ArrowDown']) player.body.applyForce(new CANNON.Vec3(0, 0, force), player.body.position);
+  if (keys['ArrowLeft']) player.body.angularVelocity.y += 0.05;
+  if (keys['ArrowRight']) player.body.angularVelocity.y -= 0.05;
+}
+
+// IA simples: inimigo persegue o jogador
+function handleEnemyAI() {
+  const direction = player.body.position.vsub(enemy.body.position);
+  direction.normalize();
+  direction.scale(150, direction);
+  enemy.body.applyForce(direction, enemy.body.position);
+}
+
+// Colisões para aplicar dano
+player.body.addEventListener('collide', (event: any) => {
+  if (event.body === enemy.body) {
+    player.car.applyDamage(10);
+    enemy.car.applyDamage(10);
+    updateLifeBars();
+    checkDestroyed(player);
+    checkDestroyed(enemy);
+  }
+});
+
+enemy.body.addEventListener('collide', (event: any) => {
+  if (event.body === player.body) {
+    // já tratado no listener do player
+  }
+});
+
+function updateLifeBars() {
+  [player, enemy].forEach((entity) => {
+    const ratio = entity.car.health / entity.car.maxHealth;
+    (entity.lifeBar.material as any).color.set(ratio > 0.3 ? 0x00ff00 : 0xff0000);
+    entity.lifeBar.scale.x = ratio;
+    entity.lifeBar.position.x = -1 + ratio;
+  });
+}
+
+function checkDestroyed(entity: CarEntity) {
+  if (entity.car.isDestroyed()) {
+    scene.remove(entity.mesh);
+    physics.world.removeBody(entity.body);
+  }
+}
+
+// Loop principal
+let lastTime = performance.now();
+function animate() {
+  requestAnimationFrame(animate);
+  const now = performance.now();
+  const delta = (now - lastTime) / 1000;
+  lastTime = now;
+
+  handlePlayerControl();
+  handleEnemyAI();
+
+  physics.step(delta);
+
+  // Sincroniza malha com corpo físico
+  [player, enemy].forEach((entity) => {
+    entity.mesh.position.copy(entity.body.position as any);
+    entity.mesh.quaternion.copy(entity.body.quaternion as any);
+  });
+
+  renderer.render(scene, camera);
+}
+
+animate();

--- a/tests/car.test.ts
+++ b/tests/car.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import Car from '../src/Car.js';
+
+test('Car perde vida ao receber dano', () => {
+  const car = new Car('test', 100);
+  car.applyDamage(30);
+  assert.equal(car.health, 70);
+});
+
+test('Car é destruído quando a vida chega a zero', () => {
+  const car = new Car('test', 50);
+  car.applyDamage(60);
+  assert.equal(car.isDestroyed(), true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+// Configuração básica do Vite para projeto em TypeScript
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold Three.js + TypeScript arena prototype with Vite config
- add Car, Arena and Physics modules plus example index.ts with bot and lifebars
- configure ESLint/Prettier and basic Node test for car health logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d26996d48333bcaed2b5cae513b3