### PR TITLE
feat: add basic upgrade system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,25 @@
 # Agents.md (Guia Vivo)
+
 Documento para **registrar decisões** e **orquestrar tarefas** futuras.
 Atualize sempre que implementar algo relevante.
 
 ## Regras importantes
+
 - Sempre verifique os testes se não quebraram.
 - Sempre crie testes para novas funcionalidades.
 - Ajuste os testes se necessário.
 
 ## 2025-08-20 - Setup inicial do projeto
+
 - Estrutura base com Three.js e TypeScript.
 - Arquivos principais criados: Car, Arena, Physics e index.
 - Configuração de Vite, ESLint e Prettier.
 - Testes unitários básicos para lógica de vida do carro.
 - Próximos passos: adicionar upgrades, múltiplos bots e suporte a multiplayer com Socket.IO.
+
+## 2025-08-23 - Sistema de upgrades
+
+- Carro pode receber upgrades de armadura que aumentam vida máxima.
+- Atalho 'u' adiciona upgrade ao jogador.
+- Testes cobrindo aplicação de upgrades.
+- Próximos passos: expandir tipos de upgrades e efeitos visuais.

--- a/src/Car.ts
+++ b/src/Car.ts
@@ -3,15 +3,19 @@
  * Responsável apenas pela lógica de vida do veículo.
  * A renderização e física são tratadas em outros módulos.
  */
+import type { Upgrade } from './Upgrade.js';
+
 export default class Car {
   id: string;
   maxHealth: number;
   health: number;
+  upgrades: Upgrade[];
 
   constructor(id: string, maxHealth = 100) {
     this.id = id;
     this.maxHealth = maxHealth;
     this.health = maxHealth;
+    this.upgrades = [];
   }
 
   /**
@@ -38,6 +42,18 @@ export default class Car {
    */
   heal(amount: number): number {
     this.health = Math.min(this.maxHealth, this.health + amount);
+    return this.health;
+  }
+
+  /**
+   * Aplica um upgrade ao carro aumentando sua vida máxima.
+   * @param upgrade Upgrade a ser aplicado.
+   * @returns Vida atual após o upgrade.
+   */
+  addUpgrade(upgrade: Upgrade): number {
+    this.upgrades.push(upgrade);
+    this.maxHealth += upgrade.bonusHealth;
+    this.health += upgrade.bonusHealth;
     return this.health;
   }
 }

--- a/src/Upgrade.ts
+++ b/src/Upgrade.ts
@@ -1,0 +1,4 @@
+export interface Upgrade {
+  id: string;
+  bonusHealth: number;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,12 @@ import Physics from './Physics.js';
 
 // Cena principal
 const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000,
+);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
@@ -51,7 +56,10 @@ function createCarEntity(id: string, color: number, position: any): CarEntity {
 
   // Barra de vida simples
   const barGeo = new THREE.PlaneGeometry(2, 0.2);
-  const barMat = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide });
+  const barMat = new THREE.MeshBasicMaterial({
+    color: 0x00ff00,
+    side: THREE.DoubleSide,
+  });
   const lifeBar = new THREE.Mesh(barGeo, barMat);
   lifeBar.position.set(0, 1, 0);
   mesh.add(lifeBar);
@@ -64,13 +72,21 @@ const enemy = createCarEntity('enemy', 0xff0000, new CANNON.Vec3(5, 0.5, 0));
 
 // Controle do jogador
 const keys: Record<string, boolean> = {};
-document.addEventListener('keydown', (e) => (keys[e.key] = true));
+document.addEventListener('keydown', (e) => {
+  keys[e.key] = true;
+  if (e.key === 'u') {
+    player.car.addUpgrade({ id: 'armor', bonusHealth: 20 });
+    updateLifeBars();
+  }
+});
 document.addEventListener('keyup', (e) => (keys[e.key] = false));
 
 function handlePlayerControl() {
   const force = 200;
-  if (keys['ArrowUp']) player.body.applyForce(new CANNON.Vec3(0, 0, -force), player.body.position);
-  if (keys['ArrowDown']) player.body.applyForce(new CANNON.Vec3(0, 0, force), player.body.position);
+  if (keys['ArrowUp'])
+    player.body.applyForce(new CANNON.Vec3(0, 0, -force), player.body.position);
+  if (keys['ArrowDown'])
+    player.body.applyForce(new CANNON.Vec3(0, 0, force), player.body.position);
   if (keys['ArrowLeft']) player.body.angularVelocity.y += 0.05;
   if (keys['ArrowRight']) player.body.angularVelocity.y -= 0.05;
 }
@@ -103,7 +119,9 @@ enemy.body.addEventListener('collide', (event: any) => {
 function updateLifeBars() {
   [player, enemy].forEach((entity) => {
     const ratio = entity.car.health / entity.car.maxHealth;
-    (entity.lifeBar.material as any).color.set(ratio > 0.3 ? 0x00ff00 : 0xff0000);
+    (entity.lifeBar.material as any).color.set(
+      ratio > 0.3 ? 0x00ff00 : 0xff0000,
+    );
     entity.lifeBar.scale.x = ratio;
     entity.lifeBar.position.x = -1 + ratio;
   });

--- a/tests/car.test.ts
+++ b/tests/car.test.ts
@@ -13,3 +13,12 @@ test('Car é destruído quando a vida chega a zero', () => {
   car.applyDamage(60);
   assert.equal(car.isDestroyed(), true);
 });
+
+test('Car recebe upgrade de armadura aumentando vida', () => {
+  const car = new Car('test', 100);
+  car.applyDamage(30);
+  car.addUpgrade({ id: 'armor', bonusHealth: 50 });
+  assert.equal(car.maxHealth, 150);
+  assert.equal(car.health, 120);
+  assert.equal(car.upgrades.length, 1);
+});


### PR DESCRIPTION
## Summary
- allow cars to receive upgrades that boost max health
- trigger player upgrade with the `u` key
- test car upgrade logic

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68aa36a66e10833386d644ca20afa410