### PR TITLE
feat: add explosion effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,9 @@ Atualize sempre que implementar algo relevante.
 - Atalho 'u' adiciona upgrade ao jogador.
 - Testes cobrindo aplicação de upgrades.
 - Próximos passos: expandir tipos de upgrades e efeitos visuais.
+
+## 2025-08-23 - Explosões visuais
+
+- Adicionadas explosões simples ao destruir carros.
+- Testes cobrindo criação e remoção das explosões.
+- Próximos passos: adicionar efeitos sonoros ao colidir e destruir carros.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ Protótipo de jogo web em Three.js onde o objetivo é destruir os outros carros 
 ```
 
 ## Roadmap
-- [ ] Sistema de upgrades/modificações.
+- [x] Sistema de upgrades/modificações.
 - [ ] Múltiplos bots com IA melhorada.
-- [ ] Explosões visuais ao destruir carros.
+- [x] Explosões visuais ao destruir carros.
 - [ ] Backend com Socket.IO e Redis para multiplayer.
 - [ ] Persistência de upgrades em banco de dados.
 - [ ] Containerização com Docker.
+- [ ] Efeitos sonoros ao colidir e destruir carros.
 
 ## Licença
 Projeto criado para fins educativos.

--- a/src/Explosion.ts
+++ b/src/Explosion.ts
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+/**
+ * Efeito visual simples de explosão.
+ * Cria uma esfera que expande e desaparece.
+ */
+export default class Explosion {
+  mesh: any;
+
+  constructor(scene: any, position: any) {
+    const geometry = new THREE.SphereGeometry(1, 8, 8);
+    const material = new THREE.MeshBasicMaterial({
+      color: 0xffa500,
+      transparent: true,
+      opacity: 1,
+    });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.position.copy(position);
+    scene.add(this.mesh);
+  }
+
+  /**
+   * Atualiza a animação da explosão.
+   * @param delta Tempo em segundos desde o último frame.
+   * @returns `true` se a explosão terminou e deve ser removida.
+   */
+  update(delta: number): boolean {
+    this.mesh.scale.addScalar(delta * 2);
+    const material = this.mesh.material as any;
+    material.opacity -= delta;
+    if (material.opacity <= 0) {
+      this.mesh.parent?.remove(this.mesh);
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import Car from './Car.js';
 import Arena from './Arena.js';
 import Physics from './Physics.js';
+import Explosion from './Explosion.js';
 
 // Cena principal
 const scene = new THREE.Scene();
@@ -70,6 +71,9 @@ function createCarEntity(id: string, color: number, position: any): CarEntity {
 const player = createCarEntity('player', 0x0000ff, new CANNON.Vec3(-5, 0.5, 0));
 const enemy = createCarEntity('enemy', 0xff0000, new CANNON.Vec3(5, 0.5, 0));
 
+// Explosões ativas
+const explosions: Explosion[] = [];
+
 // Controle do jogador
 const keys: Record<string, boolean> = {};
 document.addEventListener('keydown', (e) => {
@@ -129,6 +133,7 @@ function updateLifeBars() {
 
 function checkDestroyed(entity: CarEntity) {
   if (entity.car.isDestroyed()) {
+    explosions.push(new Explosion(scene, entity.mesh.position.clone()));
     scene.remove(entity.mesh);
     physics.world.removeBody(entity.body);
   }
@@ -146,6 +151,11 @@ function animate() {
   handleEnemyAI();
 
   physics.step(delta);
+
+  // Atualiza explosões
+  for (let i = explosions.length - 1; i >= 0; i--) {
+    if (explosions[i].update(delta)) explosions.splice(i, 1);
+  }
 
   // Sincroniza malha com corpo físico
   [player, enemy].forEach((entity) => {

--- a/tests/explosion.test.ts
+++ b/tests/explosion.test.ts
@@ -1,0 +1,75 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert';
+
+class Vector3 {
+  x: number;
+  y: number;
+  z: number;
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+  copy(v: any) {
+    this.x = v.x;
+    this.y = v.y;
+    this.z = v.z;
+    return this;
+  }
+  equals(v: any) {
+    return this.x === v.x && this.y === v.y && this.z === v.z;
+  }
+}
+
+class Scene {
+  children: any[] = [];
+  add(obj: any) {
+    this.children.push(obj);
+    obj.parent = this;
+  }
+  remove(obj: any) {
+    this.children = this.children.filter((o) => o !== obj);
+  }
+}
+
+class SphereGeometry {}
+class MeshBasicMaterial {
+  opacity: number;
+  constructor(opts: any) {
+    this.opacity = opts.opacity ?? 1;
+  }
+}
+class Mesh {
+  position = new Vector3();
+  material: any;
+  scale = { addScalar() {} };
+  parent: any;
+  constructor(_g: any, material: any) {
+    this.material = material;
+  }
+}
+
+mock.module('three', { Scene, Vector3, SphereGeometry, MeshBasicMaterial, Mesh });
+
+test('Explosion adiciona mesh na cena', async () => {
+  const { default: Explosion } = await import('../src/Explosion.js');
+  const scene = new Scene();
+  const pos = new Vector3(1, 2, 3);
+  const explosion = new Explosion(scene, pos);
+  assert.ok(scene.children.includes(explosion.mesh));
+  assert.ok(explosion.mesh.position.equals(pos));
+});
+
+test('Explosion remove mesh após finalizar', async () => {
+  const { default: Explosion } = await import('../src/Explosion.js');
+  const scene = new Scene();
+  const explosion = new Explosion(scene, new Vector3());
+  let finished = false;
+  let steps = 0;
+  while (!finished && steps < 100) {
+    finished = explosion.update(0.2);
+    steps++;
+  }
+  assert.equal(finished, true);
+  assert.ok(!scene.children.includes(explosion.mesh));
+});


### PR DESCRIPTION
## Summary
- add simple sphere-based explosion effect when cars are destroyed
- cover explosion lifecycle with tests and mock Three.js
- update roadmap with completed explosions and new sound-effects task

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node', 'three', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3a2c4d3083339a1834734b2c593d