### PR TITLE
Improve controls and camera

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,11 @@ Atualize sempre que implementar algo relevante.
 - Carros podem receber power-ups temporários de armadura.
 - Testes garantem que os efeitos expiram corretamente.
 - Próximos passos: implementar sistema de clima dinâmico e achievements para jogadores.
+
+## 2025-09-02 - Ajustes de controles e vida
+
+- Câmera reposicionável com botão direito do mouse restaurada.
+- Bots acordam ao perseguir jogador, evitando ficarem parados.
+- Explosões agora recebem instância do THREE corretamente.
+- Vida base dos carros aumentada para 200 com teste dedicado.
+- Controles ajustados para reduzir viradas involuntárias.

--- a/src/Car.ts
+++ b/src/Car.ts
@@ -13,7 +13,7 @@ export default class Car {
   upgrades: Upgrade[];
   powerUps: { data: PowerUp; remaining: number }[];
 
-  constructor(id: string, maxHealth = 100) {
+  constructor(id: string, maxHealth = 200) {
     this.id = id;
     this.maxHealth = maxHealth;
     this.health = maxHealth;

--- a/src/Controls.ts
+++ b/src/Controls.ts
@@ -60,7 +60,8 @@ export function applyCarControls(
   const brakePressed   = !!keys[' '];
 
   const rawThrottle = (forwardPressed ? 1 : 0) + (backPressed ? -1 : 0);
-  const rawSteer    = (rightPressed ? 1 : 0) - (leftPressed ? 1 : 0); // D=+1, A=-1
+  let rawSteer    = (rightPressed ? 1 : 0) - (leftPressed ? 1 : 0); // D=+1, A=-1
+  if (forwardPressed && !leftPressed && !rightPressed) rawSteer = 0;
 
   // Slew (moveToward)
   const moveToward = (a: number, b: number, maxDelta: number) =>
@@ -119,7 +120,7 @@ export function applyCarControls(
   const straightMode =
     forwardPressed && !backPressed &&
     steerAbs < 0.02 &&
-    slipAngle < 0.10 &&
+    slipAngle < 0.20 &&
     goingForward;
 
   if (straightMode) {

--- a/src/EnemyAI.ts
+++ b/src/EnemyAI.ts
@@ -12,6 +12,7 @@ export function pursuePlayer(
   targetPos: any,
   rand: () => number = Math.random,
 ): void {
+  enemyBody.wakeUp?.();
   // Direção até o player (só no plano XZ)
   const toPlayer = targetPos.vsub(enemyBody.position);
   toPlayer.y = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,25 @@ const enemies: CarEntity[] = [
 const followOffset = new THREE.Vector3(0, 5, 10);
 const explosions: Explosion[] = [];
 const dust = new Dust(THREE, scene);
+updateLifeBars();
+
+// Controle de câmera com botão direito
+let camYaw = 0;
+let camPitch = 0;
+let rotating = false;
+document.addEventListener('contextmenu', (e) => e.preventDefault());
+document.addEventListener('mousedown', (e) => {
+  if (e.button === 2) rotating = true;
+});
+document.addEventListener('mouseup', (e) => {
+  if (e.button === 2) rotating = false;
+});
+document.addEventListener('mousemove', (e) => {
+  if (!rotating) return;
+  camYaw -= e.movementX * 0.003;
+  camPitch -= e.movementY * 0.003;
+  camPitch = Math.max(-1, Math.min(1, camPitch));
+});
 
 // ================== Input (normalizado) ==================
 const keys: Record<string, boolean> = {};
@@ -170,7 +189,7 @@ function updateLifeBars() {
 
 function checkDestroyed(entity: CarEntity) {
   if (entity.car.isDestroyed()) {
-    explosions.push(new Explosion(scene, entity.mesh.position.clone()));
+    explosions.push(new Explosion(scene, entity.mesh.position.clone(), THREE));
     sound.playDestruction();
     scene.remove(entity.mesh);
     physics.world.removeBody(entity.body);
@@ -182,8 +201,8 @@ function checkDestroyed(entity: CarEntity) {
 function updateCamera() {
   const offset = computeCameraOffset(
     followOffset,
-    0, // yaw manual (botão dir) opcional
-    0, // pitch manual (botão dir) opcional
+    camYaw,
+    camPitch,
     player.mesh.quaternion as any,
   );
   const offsetVec = new THREE.Vector3(offset.x, offset.y, offset.z);

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -62,6 +62,7 @@ test('pursuePlayer aplica força em direção ao player', () => {
         return target;
       },
     },
+    wakeUp: () => {},
   };
   const playerPos = new StubVec3(10, 0, 0);
   pursuePlayer(enemyBody, playerPos, () => 0.5);
@@ -69,4 +70,26 @@ test('pursuePlayer aplica força em direção ao player', () => {
   assert(applied!.x > 0);
   assert(applied!.length() >= 8000);
   assert.equal(enemyBody.angularVelocity.y, 0);
+});
+
+test('pursuePlayer acorda o corpo adormecido', () => {
+  let woke = false;
+  const enemyBody: any = {
+    position: new StubVec3(0, 0, 0),
+    angularVelocity: { y: 0 },
+    applyForce: () => {},
+    torque: { y: 0 },
+    quaternion: {
+      toEuler: (v: any) => {
+        v.x = 0; v.y = 0; v.z = 0;
+      },
+      vmult: (v: StubVec3, target: StubVec3) => {
+        target.x = v.x; target.y = v.y; target.z = v.z; return target;
+      },
+    },
+    velocity: new StubVec3(),
+    wakeUp: () => { woke = true; },
+  };
+  pursuePlayer(enemyBody, new StubVec3(1, 0, 0), () => 0.5);
+  assert.equal(woke, true);
 });

--- a/tests/car.test.ts
+++ b/tests/car.test.ts
@@ -2,6 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert';
 import Car from '../src/Car.js';
 
+test('Car inicia com vida base aumentada', () => {
+  const car = new Car('test');
+  assert.equal(car.maxHealth, 200);
+  assert.equal(car.health, 200);
+});
+
 test('Car perde vida ao receber dano', () => {
   const car = new Car('test', 100);
   car.applyDamage(30);

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 test('Dockerfile expõe a porta 4173', () => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  const dockerfilePath = resolve(__dirname, '..', 'Dockerfile');
+  const dockerfilePath = resolve(__dirname, '..', '..', 'Dockerfile');
   assert.ok(existsSync(dockerfilePath), 'Dockerfile deve existir');
   const content = readFileSync(dockerfilePath, 'utf-8');
   assert.ok(content.includes('EXPOSE 4173'), 'Dockerfile deve expor porta 4173');


### PR DESCRIPTION
## Summary
- Restore right-click camera rotation with yaw/pitch handling
- Wake sleeping bots and pass THREE instance to explosions
- Increase default car health to 200 and tweak steering stability

## Testing
- `npm test` *(fails: Cannot find package 'cannon-es')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8bed75788333827fd1feb68b7ceb