### PR TITLE
feat: add basic achievements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,10 @@ Atualize sempre que implementar algo relevante.
 ## 2025-09-05 - Correção de inicialização da câmera
 
 - camYaw e camPitch definidos antes do primeiro updateCamera para evitar ReferenceError.
+
+## 2025-09-06 - Sistema de achievements e ajustes de início
+
+- Conquista 'Primeiro Abate' ao destruir o primeiro inimigo.
+- Delta de tempo reiniciado ao iniciar para evitar travamento inicial.
+- Teste cobrindo desbloqueio de achievements.
+- Próximos passos: implementar leaderboard global de pontuações.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Protótipo de jogo web em Three.js onde o objetivo é destruir os outros carros 
 - [x] Power-ups temporários espalhados pela arena.
 - [ ] Sistema de replays das partidas.
 - [ ] Sistema de clima dinâmico (dia/noite e chuva).
-- [ ] Sistema de achievements para jogadores.
+- [x] Sistema de achievements para jogadores.
+- [ ] Leaderboard global de pontuações.
 
 ## Licença
 Projeto criado para fins educativos.

--- a/src/Achievements.ts
+++ b/src/Achievements.ts
@@ -1,0 +1,17 @@
+export default class Achievements {
+  private kills = 0;
+  private unlocked = new Set<string>();
+
+  registerKill(): string | null {
+    this.kills++;
+    if (this.kills === 1 && !this.unlocked.has('first_blood')) {
+      this.unlocked.add('first_blood');
+      return 'Primeiro Abate';
+    }
+    return null;
+  }
+
+  has(id: string): boolean {
+    return this.unlocked.has(id);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import Dust from './Dust.js';
 import GameState from './GameState.js';
 import { directionalDamage } from './Damage.js';
 import { syncEntityMeshes } from './entitySync.js';
+import Achievements from './Achievements.js';
 
 // Cena principal
 const scene = new THREE.Scene();
@@ -23,7 +24,12 @@ const menuEl = document.getElementById('menu') as HTMLElement;
 const messageEl = document.getElementById('menu-message') as HTMLElement;
 const buttonEl = document.getElementById('menu-button') as HTMLButtonElement;
 const sound = new Sound();
-const gameState = new GameState(menuEl, messageEl, buttonEl, () => sound.playBackground());
+let lastTime = performance.now();
+const gameState = new GameState(menuEl, messageEl, buttonEl, () => {
+  sound.playBackground();
+  lastTime = performance.now();
+});
+const achievements = new Achievements();
 
 // Luzes
 const light = new THREE.DirectionalLight(0xffffff, 1);
@@ -210,7 +216,11 @@ function checkDestroyed(entity: CarEntity) {
     scene.remove(entity.mesh);
     physics.world.removeBody(entity.body);
     const idx = enemies.indexOf(entity);
-    if (idx !== -1) enemies.splice(idx, 1);
+    if (idx !== -1) {
+      enemies.splice(idx, 1);
+      const unlocked = achievements.registerKill();
+      if (unlocked) console.log(`Achievement desbloqueado: ${unlocked}`);
+    }
     if (entity === player) {
       gameState.gameOver();
     }
@@ -230,7 +240,6 @@ function updateCamera() {
 }
 
 // Loop principal
-let lastTime = performance.now();
 function animate() {
   requestAnimationFrame(animate);
   const now = performance.now();

--- a/tests/achievements.test.ts
+++ b/tests/achievements.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import Achievements from '../src/Achievements.js';
+
+test('Desbloqueia Primeira Morte na primeira kill', () => {
+  const ach = new Achievements();
+  const title = ach.registerKill();
+  assert.equal(title, 'Primeiro Abate');
+  assert.equal(ach.has('first_blood'), true);
+  assert.equal(ach.registerKill(), null);
+});


### PR DESCRIPTION
## Summary
- add simple achievements tracker with first blood unlock
- reset frame delta when starting to avoid black screen
- document achievements and add leaderboard to roadmap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb073582483339019fef697211951