### PR TITLE
feat: allow car color selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,10 @@ Atualize sempre que implementar algo relevante.
 - Ciclo de clima dinâmico controlando luzes do cenário.
 - Testes garantem atualização do ciclo de clima.
 - Próximos passos: sistema de personalização de carros.
+
+## 2025-09-08 - Personalização de carros e ajuste de câmera
+
+- Jogador pode escolher a cor do carro antes de iniciar (teclas 1-3).
+- camYaw e camPitch reiniciados ao iniciar para evitar tela escura.
+- Teste cobrindo alteração de cor via setCarColor.
+- Próximos passos: implementar modo espectador após destruição do jogador.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Protótipo de jogo web em Three.js onde o objetivo é destruir os outros carros 
 - [x] Sistema de clima dinâmico (dia/noite e chuva).
 - [x] Sistema de achievements para jogadores.
 - [ ] Leaderboard global de pontuações.
-- [ ] Sistema de personalização de carros.
+- [x] Sistema de personalização de carros.
+- [ ] Modo espectador após destruição do jogador.
 
 ## Licença
 Projeto criado para fins educativos.

--- a/src/Customization.ts
+++ b/src/Customization.ts
@@ -1,0 +1,7 @@
+export interface Paintable {
+  material: { color: { set: (c: number) => void } };
+}
+
+export function setCarColor(entity: Paintable, color: number): void {
+  entity.material.color.set(color);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { directionalDamage } from './Damage.js';
 import { syncEntityMeshes } from './entitySync.js';
 import Achievements from './Achievements.js';
 import Weather from './Weather.js';
+import { setCarColor } from './Customization.js';
 
 // Cena principal
 const scene = new THREE.Scene();
@@ -45,6 +46,7 @@ interface CarEntity {
   mesh: any;
   body: any;
   lifeBar: any;
+  material: any;
 }
 
 function createCarEntity(id: string, color: number, position: any): CarEntity {
@@ -107,10 +109,11 @@ function createCarEntity(id: string, color: number, position: any): CarEntity {
   lifeBar.position.set(0, 1.2, 0);
   group.add(lifeBar);
 
-  return { car, mesh: group, body, lifeBar };
+  return { car, mesh: group, body, lifeBar, material: bodyMaterial };
 }
-
-const player = createCarEntity('player', 0x0000ff, new CANNON.Vec3(-5, 0.5, 0));
+const availableColors = [0x0000ff, 0xff0000, 0x00ff00];
+let selectedColor = availableColors[0];
+const player = createCarEntity('player', selectedColor, new CANNON.Vec3(-5, 0.5, 0));
 const enemies: CarEntity[] = [
   createCarEntity('enemy1', 0xff0000, new CANNON.Vec3(5, 0.5, 0)),
   createCarEntity('enemy2', 0x00ff00, new CANNON.Vec3(0, 0.5, 5)),
@@ -118,6 +121,8 @@ const enemies: CarEntity[] = [
 
 const gameState = new GameState(menuEl, messageEl, buttonEl, () => {
   // Garante sincronização antes de iniciar para evitar tela preta
+  camYaw = 0;
+  camPitch = 0;
   syncEntityMeshes([player, ...enemies]);
   updateCamera();
   sound.playBackground();
@@ -173,6 +178,11 @@ document.addEventListener('keydown', (e) => {
     gameState.start();
     return;
   }
+  if (!gameState.isPlaying() && ['1', '2', '3'].includes(k)) {
+    selectedColor = availableColors[Number(k) - 1];
+    setCarColor(player, selectedColor);
+    return;
+    }
   keys[k] = true;
   if (k === 'u') {
     player.car.addUpgrade({ id: 'armor', bonusHealth: 20 });

--- a/tests/customization.test.ts
+++ b/tests/customization.test.ts
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { setCarColor } from '../src/Customization.js';
+
+test('setCarColor altera cor do material', () => {
+  const entity = { material: { color: { value: 0, set(c: number) { this.value = c; } } } };
+  setCarColor(entity as any, 0xff0000);
+  assert.equal(entity.material.color.value, 0xff0000);
+});


### PR DESCRIPTION
## Summary
- let players pick the car color before starting
- reset camera orientation to prevent black screen
- track customization work and plan spectator mode in roadmap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abb69e2984833393c69a4519aae29f