### PR TITLE
fix: prevent black screen when starting game quickly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,3 +134,8 @@ Atualize sempre que implementar algo relevante.
 - camYaw e camPitch reiniciados ao iniciar para evitar tela escura.
 - Teste cobrindo alteração de cor via setCarColor.
 - Próximos passos: implementar modo espectador após destruição do jogador.
+
+## 2025-09-09 - Correção de corrida de inicialização
+
+- camYaw e camPitch declarados antes da criação do GameState para evitar ReferenceError ao iniciar rapidamente.
+- Teste garantindo reinicialização das variáveis de câmera.

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ const messageEl = document.getElementById('menu-message') as HTMLElement;
 const buttonEl = document.getElementById('menu-button') as HTMLButtonElement;
 const sound = new Sound();
 let lastTime = performance.now();
+let camYaw = 0;
+let camPitch = 0;
 
 // Luzes
 const light = new THREE.DirectionalLight(0xffffff, 1);
@@ -136,8 +138,6 @@ const dust = new Dust(THREE, scene);
 updateLifeBars();
 
 // Controle de câmera com botão direito
-let camYaw = 0;
-let camPitch = 0;
 let rotating = false;
 document.addEventListener('contextmenu', (e) => e.preventDefault());
 document.addEventListener('mousedown', (e) => {

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import GameState from '../src/GameState.js';
+
+test('iniciar imediatamente reinicia variáveis de câmera sem erro', () => {
+  const menuEl: any = { style: { display: 'none' } };
+  const msgEl: any = { textContent: '' };
+  const btnEl: any = { textContent: '', addEventListener: () => {} };
+  let camYaw = 5;
+  let camPitch = 5;
+  const gs = new GameState(menuEl, msgEl, btnEl, () => {
+    camYaw = 0;
+    camPitch = 0;
+  });
+  assert.doesNotThrow(() => gs.start());
+  assert.equal(camYaw, 0);
+  assert.equal(camPitch, 0);
+});


### PR DESCRIPTION
## Summary
- initialize camera yaw/pitch before creating game state to avoid ReferenceError on fast start
- test immediate GameState start resets camera orientation variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb8c2469c83338a45f2733f1e0f37