### PR TITLE
Reset input state when restarting game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,8 @@ Atualize sempre que implementar algo relevante.
 - Implementada função de reinício para restaurar jogador e inimigos ao clicar em Iniciar.
 - Função `resetCarEntity` reutilizável para resetar carros.
 - Teste cobrindo reinicialização de entidades.
+
+## 2025-09-11 - Limpeza de estado ao reiniciar
+
+- Reset das teclas pressionadas e remoção de explosões pendentes ao reiniciar o jogo.
+- Função `clearKeys` adicionada para limpar mapa de entrada com teste dedicado.

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -24,3 +24,9 @@ export function resetCarEntity(entity: ResettableEntity, position: Vec3Like): vo
   entity.mesh.position.set(position.x, position.y, position.z);
   entity.mesh.quaternion.set(0, 0, 0, 1);
 }
+
+export function clearKeys(keys: Record<string, boolean>): void {
+  Object.keys(keys).forEach((k) => {
+    keys[k] = false;
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { syncEntityMeshes } from './entitySync.js';
 import Achievements from './Achievements.js';
 import Weather from './Weather.js';
 import { setCarColor } from './Customization.js';
-import { resetCarEntity } from './Reset.js';
+import { resetCarEntity, clearKeys } from './Reset.js';
 
 // Cena principal
 const scene = new THREE.Scene();
@@ -142,7 +142,10 @@ function resetGame() {
     createCarEntity('enemy1', 0xff0000, enemyStarts[0]),
     createCarEntity('enemy2', 0x00ff00, enemyStarts[1]),
   );
-
+  clearKeys(keys);
+  rotating = false;
+  explosions.forEach((ex) => scene.remove(ex.mesh));
+  explosions.length = 0;
   updateLifeBars();
   camYaw = 0;
   camPitch = 0;

--- a/tests/reset.test.ts
+++ b/tests/reset.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import Car from '../src/Car.js';
-import { resetCarEntity } from '../src/Reset.js';
+import { resetCarEntity, clearKeys } from '../src/Reset.js';
 
 class Vec {
   x = 0;
@@ -38,4 +38,11 @@ test('resetCarEntity restaura vida e transforma', () => {
   assert.equal(entity.body.position.x, 10);
   assert.equal(entity.body.velocity.y, 0);
   assert.equal(entity.mesh.position.z, -5);
+});
+
+test('clearKeys desativa todas as teclas', () => {
+  const keys: Record<string, boolean> = { w: true, a: true };
+  clearKeys(keys);
+  assert.equal(keys.w, false);
+  assert.equal(keys.a, false);
 });


### PR DESCRIPTION
## Summary
- clear pressed keys and leftover explosions whenever the game restarts
- add `clearKeys` helper with unit test
- document reset behavior in AGENTS log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abbf1cabe08333bf571104d11097ae