### PR TITLE
Fix dark screen on game restart by resetting weather

### DIFF
--- a/src/Weather.ts
+++ b/src/Weather.ts
@@ -23,6 +23,16 @@ export default class Weather {
   }
 
   /**
+   * Reinicia o ciclo climático para o dia inicial.
+   * Utilizado ao reiniciar o jogo para evitar tela escura.
+   */
+  reset(): void {
+    this.t = 0;
+    this.dir.intensity = 1;
+    this.amb.intensity = 0.5;
+  }
+
+  /**
    * Retorna o valor normalizado do ciclo atual (0 = dia, 1 = volta ao dia).
    */
   getCycle(): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,7 @@ function resetGame() {
   rotating = false;
   explosions.forEach((ex) => scene.remove(ex.mesh));
   explosions.length = 0;
+  weather.reset();
   updateLifeBars();
   camYaw = 0;
   camPitch = 0;

--- a/tests/weather.test.ts
+++ b/tests/weather.test.ts
@@ -22,3 +22,14 @@ test('weather cycle wraps around', () => {
   for (let i = 0; i < 1000; i++) weather.update(1);
   assert.equal(weather.getCycle() < 1, true);
 });
+
+test('weather reset restaura ciclo e intensidades', () => {
+  const dir = new Light();
+  const amb = new Light();
+  const weather = new Weather(dir as any, amb as any);
+  weather.update(10); // avança para noite
+  weather.reset();
+  assert.equal(weather.getCycle(), 0);
+  assert.equal(dir.intensity, 1);
+  assert.equal(amb.intensity, 0.5);
+});


### PR DESCRIPTION
## Summary
- add `Weather.reset` to restore lighting cycle to daylight
- call `weather.reset()` on game start so the arena isn't dark
- test weather reset to ensure cycle and intensities reset

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abc1a831dc8333977ee8a5b43103d9