### PR TITLE
fix: ensure input state is ready on quick start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ const sound = new Sound();
 let lastTime = performance.now();
 let camYaw = 0;
 let camPitch = 0;
+const keys: Record<string, boolean> = {};
 
 // Luzes
 const light = new THREE.DirectionalLight(0xffffff, 1);
@@ -187,7 +188,6 @@ syncEntityMeshes([player, ...enemies]);
 updateCamera();
 
 // ================== Input (normalizado) ==================
-const keys: Record<string, boolean> = {};
 const normalizeKey = (k: string) => k.toLowerCase();
 const mapArrow = (k: string) => {
   switch (k) {

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -1,18 +1,22 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import GameState from '../src/GameState.js';
+import { clearKeys } from '../src/Reset.js';
 
-test('iniciar imediatamente reinicia variáveis de câmera sem erro', () => {
+test('iniciar imediatamente reinicia variáveis e limpa teclas', () => {
   const menuEl: any = { style: { display: 'none' } };
   const msgEl: any = { textContent: '' };
   const btnEl: any = { textContent: '', addEventListener: () => {} };
   let camYaw = 5;
   let camPitch = 5;
+  const keys: Record<string, boolean> = { w: true };
   const gs = new GameState(menuEl, msgEl, btnEl, () => {
     camYaw = 0;
     camPitch = 0;
+    clearKeys(keys);
   });
   assert.doesNotThrow(() => gs.start());
   assert.equal(camYaw, 0);
   assert.equal(camPitch, 0);
+  assert.equal(keys.w, false);
 });


### PR DESCRIPTION
## Summary
- initialize keyboard state before setting up game state to avoid early start crash
- test that immediate start clears keys and resets camera

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68abc2af4ae083339283b352a6d74bb7