### PR TITLE
fix: prevent early start crash by initializing input state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,9 @@ Atualize sempre que implementar algo relevante.
 
 - Reset das teclas pressionadas e remoção de explosões pendentes ao reiniciar o jogo.
 - Função `clearKeys` adicionada para limpar mapa de entrada com teste dedicado.
+
+## 2025-09-12 - Prevenção de erros ao iniciar rapidamente
+
+- Mapa de teclas e flag de rotação declarados antes de `resetGame` para evitar ReferenceError.
+- Teste garantindo limpeza do mapa de teclas ao iniciar imediatamente.
+- Próximos passos: investigar suporte a múltiplos jogadores no sistema de entrada.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,12 @@ import { resetCarEntity, clearKeys } from './Reset.js';
 
 // Cena principal
 const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000,
+);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
@@ -79,9 +84,9 @@ function createCarEntity(id: string, color: number, position: any): CarEntity {
   const wheelMat = new THREE.MeshStandardMaterial({ color: 0x333333 });
   const wheelPositions = [
     [-1, 0.25, -1.5],
-    [ 1, 0.25, -1.5],
-    [-1, 0.25,  1.5],
-    [ 1, 0.25,  1.5],
+    [1, 0.25, -1.5],
+    [-1, 0.25, 1.5],
+    [1, 0.25, 1.5],
   ];
   wheelPositions.forEach((pos) => {
     const wheel = new THREE.Mesh(wheelGeo, wheelMat);
@@ -99,15 +104,18 @@ function createCarEntity(id: string, color: number, position: any): CarEntity {
   body.position.copy(position);
 
   // Damping / rotação (evita capote e vibrações)
-  body.angularFactor.set(0, 1, 0);   // gira só no Y
-  body.linearDamping = 0.20;         // arrasto linear
-  body.angularDamping = 0.55;        // arrasto angular
+  body.angularFactor.set(0, 1, 0); // gira só no Y
+  body.linearDamping = 0.2; // arrasto linear
+  body.angularDamping = 0.55; // arrasto angular
 
   physics.world.addBody(body);
 
   // Barra de vida
   const barGeo = new THREE.PlaneGeometry(2, 0.2);
-  const barMat = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide });
+  const barMat = new THREE.MeshBasicMaterial({
+    color: 0x00ff00,
+    side: THREE.DoubleSide,
+  });
   const lifeBar = new THREE.Mesh(barGeo, barMat);
   lifeBar.position.set(0, 1.2, 0);
   group.add(lifeBar);
@@ -117,21 +125,25 @@ function createCarEntity(id: string, color: number, position: any): CarEntity {
 const availableColors = [0x0000ff, 0xff0000, 0x00ff00];
 let selectedColor = availableColors[0];
 const playerStart = new CANNON.Vec3(-5, 0.5, 0);
-const enemyStarts = [
-  new CANNON.Vec3(5, 0.5, 0),
-  new CANNON.Vec3(0, 0.5, 5),
-];
+const enemyStarts = [new CANNON.Vec3(5, 0.5, 0), new CANNON.Vec3(0, 0.5, 5)];
 const player = createCarEntity('player', selectedColor, playerStart);
 const enemies: CarEntity[] = [
   createCarEntity('enemy1', 0xff0000, enemyStarts[0]),
   createCarEntity('enemy2', 0x00ff00, enemyStarts[1]),
 ];
 
+// Mapa de teclas deve existir antes de qualquer reinicialização
+// para evitar ReferenceError caso o jogo seja iniciado rapidamente.
+const keys: Record<string, boolean> = {};
+// Flag de rotação da câmera definida antecipadamente pela mesma razão.
+let rotating = false;
+
 function resetGame() {
   resetCarEntity(player, playerStart);
   setCarColor(player, selectedColor);
   if (!scene.children.includes(player.mesh)) scene.add(player.mesh);
-  if (!physics.world.bodies.includes(player.body)) physics.world.addBody(player.body);
+  if (!physics.world.bodies.includes(player.body))
+    physics.world.addBody(player.body);
 
   enemies.forEach((e) => {
     scene.remove(e.mesh);
@@ -167,7 +179,6 @@ const dust = new Dust(THREE, scene);
 updateLifeBars();
 
 // Controle de câmera com botão direito
-let rotating = false;
 document.addEventListener('contextmenu', (e) => e.preventDefault());
 document.addEventListener('mousedown', (e) => {
   if (e.button === 2) rotating = true;
@@ -187,7 +198,6 @@ syncEntityMeshes([player, ...enemies]);
 updateCamera();
 
 // ================== Input (normalizado) ==================
-const keys: Record<string, boolean> = {};
 const normalizeKey = (k: string) => k.toLowerCase();
 const mapArrow = (k: string) => {
   switch (k) {
@@ -211,7 +221,7 @@ document.addEventListener('keydown', (e) => {
     selectedColor = availableColors[Number(k) - 1];
     setCarColor(player, selectedColor);
     return;
-    }
+  }
   keys[k] = true;
   if (k === 'u') {
     player.car.addUpgrade({ id: 'armor', bonusHealth: 20 });
@@ -247,7 +257,9 @@ player.body.addEventListener('collide', (event: any) => {
 function updateLifeBars() {
   [player, ...enemies].forEach((entity) => {
     const ratio = entity.car.health / entity.car.maxHealth;
-    (entity.lifeBar.material as any).color.set(ratio > 0.3 ? 0x00ff00 : 0xff0000);
+    (entity.lifeBar.material as any).color.set(
+      ratio > 0.3 ? 0x00ff00 : 0xff0000,
+    );
     entity.lifeBar.scale.x = ratio;
     entity.lifeBar.position.x = -1 + ratio;
   });

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import GameState from '../src/GameState.js';
+import { clearKeys } from '../src/Reset.js';
 
 test('iniciar imediatamente reinicia variáveis de câmera sem erro', () => {
   const menuEl: any = { style: { display: 'none' } };
@@ -15,4 +16,16 @@ test('iniciar imediatamente reinicia variáveis de câmera sem erro', () => {
   assert.doesNotThrow(() => gs.start());
   assert.equal(camYaw, 0);
   assert.equal(camPitch, 0);
+});
+
+test('iniciar imediatamente limpa mapa de teclas', () => {
+  const menuEl: any = { style: { display: 'none' } };
+  const msgEl: any = { textContent: '' };
+  const btnEl: any = { textContent: '', addEventListener: () => {} };
+  const keys: Record<string, boolean> = { w: true };
+  const gs = new GameState(menuEl, msgEl, btnEl, () => {
+    clearKeys(keys);
+  });
+  assert.doesNotThrow(() => gs.start());
+  assert.equal(keys.w, false);
 });


### PR DESCRIPTION
## Summary
- initialize key map and camera rotation flag before resetGame to avoid early-start ReferenceErrors
- add test ensuring start clears key map without errors
- document change in AGENTS log

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68abc2b6d5a08333a87ab856288d778f