### PR TITLE
fix: remove duplicate key map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,7 @@ Atualize sempre que implementar algo relevante.
 - Mapa de teclas e flag de rotação declarados antes de `resetGame` para evitar ReferenceError.
 - Teste garantindo limpeza do mapa de teclas ao iniciar imediatamente.
 - Próximos passos: investigar suporte a múltiplos jogadores no sistema de entrada.
+
+## 2025-09-13 - Correção de duplicação de variáveis
+
+- Removidas declarações duplicadas de mapa de teclas e flag de rotação no `index.ts`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,11 @@ const sound = new Sound();
 let lastTime = performance.now();
 let camYaw = 0;
 let camPitch = 0;
+// Mapa de teclas deve existir antes de qualquer reinicialização
+// para evitar ReferenceError caso o jogo seja iniciado rapidamente.
 const keys: Record<string, boolean> = {};
+// Flag de rotação da câmera definida antecipadamente pela mesma razão.
+let rotating = false;
 
 // Luzes
 const light = new THREE.DirectionalLight(0xffffff, 1);
@@ -132,12 +136,6 @@ const enemies: CarEntity[] = [
   createCarEntity('enemy1', 0xff0000, enemyStarts[0]),
   createCarEntity('enemy2', 0x00ff00, enemyStarts[1]),
 ];
-
-// Mapa de teclas deve existir antes de qualquer reinicialização
-// para evitar ReferenceError caso o jogo seja iniciado rapidamente.
-const keys: Record<string, boolean> = {};
-// Flag de rotação da câmera definida antecipadamente pela mesma razão.
-let rotating = false;
 
 function resetGame() {
   resetCarEntity(player, playerStart);


### PR DESCRIPTION
## Summary
- avoid build failure by defining keyboard state and camera rotation flag once before resets
- note fix in project log

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ace79a70848333be0f4880b8aeb4a7