### PR TITLE
Add bodies array to cannon stub

### DIFF
--- a/src/stubs/cannon-es.ts
+++ b/src/stubs/cannon-es.ts
@@ -78,9 +78,10 @@ export class World {
   defaultContactMaterial: any = {};
   solver: any = { iterations: 0, tolerance: 0 };
   allowSleep = false;
+  bodies: Body[] = [];
   constructor(opts:any={}){ this.gravity = opts.gravity || new Vec3(); }
-  addBody(_body: Body){}
-  removeBody(_body: Body){}
+  addBody(body: Body){ this.bodies.push(body); }
+  removeBody(body: Body){ this.bodies = this.bodies.filter(b=>b!==body); }
   step(_dt: number, _dt2?: number, _dt3?: number){}
 }
 

--- a/tests/cannon.test.ts
+++ b/tests/cannon.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { Body } from '../src/stubs/cannon-es.js';
+import { Body, World } from '../src/stubs/cannon-es.js';
 
 test('Body quaternion aceita setFromEuler', () => {
   const b = new Body();
@@ -17,4 +17,13 @@ test('Body quaternion aceita set', () => {
     { x: b.quaternion.x, y: b.quaternion.y, z: b.quaternion.z, w: b.quaternion.w },
     { x: 1, y: 2, z: 3, w: 4 },
   );
+});
+
+test('World gerencia array bodies', () => {
+  const world = new World();
+  const body = new Body();
+  world.addBody(body);
+  assert.ok(world.bodies.includes(body));
+  world.removeBody(body);
+  assert.ok(!world.bodies.includes(body));
 });


### PR DESCRIPTION
## Summary
- make stubbed cannon-es World track bodies and allow add/remove
- test that World manages bodies array

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aceae3128483338761fb64b98cb92b