### PR TITLE
Fix key tracking and add Docker Compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,9 @@ Atualize sempre que implementar algo relevante.
 - Controles de entrada agora utilizam `createKeyTracker`, permitindo extensões para múltiplos jogadores.
 - Testes garantindo registro de teclas e mapeamentos customizados.
 - Próximos passos: utilizar `createKeyTracker` para adicionar segundo jogador controlado via setas.
+
+## 2025-09-16 - Robustez de entrada e docker-compose
+
+- `createKeyTracker` agora usa `event.code` como fallback para garantir movimento com WASD e setas.
+- Teste cobrindo o uso de `code` quando `key` está ausente.
+- `docker-compose.yml` adicionado para subir o jogo com um único comando.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Protótipo de jogo web em Three.js onde o objetivo é destruir os outros carros 
    docker run -p 4173:4173 car-destruction
    ```
 
+## Rodar com Docker Compose
+
+1. Subir o serviço:
+   ```bash
+   docker compose up --build
+   ```
+
 ## Controles
 
 - **W** ou **seta para cima**: acelerar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "4173:4173"
+    command: npm run preview -- --host

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,4 +1,4 @@
-export const normalizeKey = (k: string) => k.toLowerCase();
+export const normalizeKey = (k: string | undefined) => (k ?? '').toLowerCase();
 export const mapArrow = (k: string) => {
   switch (k) {
     case 'arrowup':
@@ -27,7 +27,7 @@ export function createKeyTracker(
   const keys: Record<string, boolean> = {};
 
   const handle = (pressed: boolean) => (e: any) => {
-    let k = normalizeKey(e.key);
+    let k = normalizeKey(e.key || e.code);
     k = mapping[k] ?? mapArrow(k);
     keys[k] = pressed;
     onKey?.(k, pressed);

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -27,6 +27,21 @@ test('createKeyTracker registra teclas e mapeia setas', () => {
   tracker.dispose();
 });
 
+test('createKeyTracker usa code quando key ausente', () => {
+  const handlers: Record<string, (e: any) => void> = {};
+  const target = {
+    addEventListener: (name: string, fn: any) => {
+      handlers[name] = fn;
+    },
+    removeEventListener: () => {},
+  } as any;
+
+  const tracker = createKeyTracker(target);
+  handlers.keydown({ code: 'ArrowUp', preventDefault() {} });
+  assert.equal(tracker.keys['w'], true);
+  tracker.dispose();
+});
+
 test('createKeyTracker aceita mapeamento customizado', () => {
   const handlers: Record<string, (e: any) => void> = {};
   const target = {


### PR DESCRIPTION
## Summary
- ensure keyboard tracker falls back to `event.code` so WASD and arrow keys always work
- add Docker Compose file for easier backend startup
- document docker compose usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf10ca330833383828d24c81ced04