### PR TITLE
Fix key code fallback and add sound volume control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,3 +180,9 @@ Atualize sempre que implementar algo relevante.
 - `createKeyTracker` agora usa `event.code` como fallback para garantir movimento com WASD e setas.
 - Teste cobrindo o uso de `code` quando `key` está ausente.
 - `docker-compose.yml` adicionado para subir o jogo com um único comando.
+
+## 2025-09-17 - Correção de teclas e controle de volume
+
+- `normalizeKey` interpreta códigos como `KeyW` e `Space`, garantindo movimento mesmo sem `key`.
+- `Sound` agora possui `setVolume` para ajustar volume globalmente.
+- Testes atualizados para cobrir novos comportamentos de entrada e volume.

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,4 +1,9 @@
-export const normalizeKey = (k: string | undefined) => (k ?? '').toLowerCase();
+export const normalizeKey = (k: string | undefined) => {
+  const lower = (k ?? '').toLowerCase();
+  if (lower.startsWith('key')) return lower.slice(3);
+  if (lower === 'space') return ' ';
+  return lower;
+};
 export const mapArrow = (k: string) => {
   switch (k) {
     case 'arrowup':

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -2,6 +2,7 @@ export default class Sound {
   private collisionAudio: HTMLAudioElement;
   private destructionAudio: HTMLAudioElement;
   private backgroundAudio: HTMLAudioElement;
+  private volume = 1;
 
   constructor(
     collisionSrc = 'assets/collision.wav',
@@ -31,5 +32,12 @@ export default class Sound {
 
   setBackgroundIntensity(intensity: number): void {
     this.backgroundAudio.playbackRate = intensity;
+  }
+
+  setVolume(volume: number): void {
+    this.volume = Math.min(1, Math.max(0, volume));
+    this.collisionAudio.volume = this.volume;
+    this.destructionAudio.volume = this.volume;
+    this.backgroundAudio.volume = this.volume;
   }
 }

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -39,7 +39,14 @@ test('createKeyTracker usa code quando key ausente', () => {
   const tracker = createKeyTracker(target);
   handlers.keydown({ code: 'ArrowUp', preventDefault() {} });
   assert.equal(tracker.keys['w'], true);
+  handlers.keydown({ code: 'KeyW', preventDefault() {} });
+  assert.equal(tracker.keys['w'], true);
   tracker.dispose();
+});
+
+test('normalizeKey converte codes especiais', () => {
+  assert.equal(normalizeKey('KeyW'), 'w');
+  assert.equal(normalizeKey('Space'), ' ');
 });
 
 test('createKeyTracker aceita mapeamento customizado', () => {

--- a/tests/sound.test.ts
+++ b/tests/sound.test.ts
@@ -9,6 +9,7 @@ test('Sound reproduz efeitos e música de fundo', () => {
     currentTime = 0;
     loop = false;
     playbackRate = 1;
+    volume = 1;
     play = playFn;
     pause = () => {};
     constructor(_src?: string) {}
@@ -22,9 +23,11 @@ test('Sound reproduz efeitos e música de fundo', () => {
   sound.playDestruction();
   sound.playBackground();
   sound.setBackgroundIntensity(1.5);
+  sound.setVolume(0.5);
 
   assert.equal(playFn.mock.callCount(), 3);
   assert.equal((sound as any).backgroundAudio.playbackRate, 1.5);
+  assert.equal((sound as any).collisionAudio.volume, 0.5);
 
   if (OriginalAudio) (globalThis as any).Audio = OriginalAudio;
 });


### PR DESCRIPTION
## Summary
- handle `KeyW` and `Space` codes so controls work even without `event.key`
- add global `setVolume` control for sounds
- expand tests for input and audio volume

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf36b362c8333aada3028bc6d0a25