### PR TITLE
Improve arrow key handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,3 +186,8 @@ Atualize sempre que implementar algo relevante.
 - `normalizeKey` interpreta códigos como `KeyW` e `Space`, garantindo movimento mesmo sem `key`.
 - `Sound` agora possui `setVolume` para ajustar volume globalmente.
 - Testes atualizados para cobrir novos comportamentos de entrada e volume.
+
+## 2025-09-18 - Robusteza de setas no controle
+
+- `mapArrow` agora também reconhece `'Up'`, `'Down'`, `'Left'` e `'Right'`, garantindo movimento do carro em navegadores que retornam nomes abreviados.
+- Teste expandido para cobrir os novos mapeamentos.

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -7,12 +7,16 @@ export const normalizeKey = (k: string | undefined) => {
 export const mapArrow = (k: string) => {
   switch (k) {
     case 'arrowup':
+    case 'up':
       return 'w';
     case 'arrowdown':
+    case 'down':
       return 's';
     case 'arrowleft':
+    case 'left':
       return 'a';
     case 'arrowright':
+    case 'right':
       return 'd';
     default:
       return k;

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -7,6 +7,10 @@ test('mapArrow converte setas para WASD', () => {
   assert.equal(mapArrow(normalizeKey('ArrowDown')), 's');
   assert.equal(mapArrow(normalizeKey('ArrowLeft')), 'a');
   assert.equal(mapArrow(normalizeKey('ArrowRight')), 'd');
+  assert.equal(mapArrow(normalizeKey('Up')), 'w');
+  assert.equal(mapArrow(normalizeKey('Down')), 's');
+  assert.equal(mapArrow(normalizeKey('Left')), 'a');
+  assert.equal(mapArrow(normalizeKey('Right')), 'd');
 });
 
 test('createKeyTracker registra teclas e mapeia setas', () => {


### PR DESCRIPTION
## Summary
- fix non-moving car when some browsers emit Up/Down/Left/Right instead of Arrow* keys
- extend tests for new arrow mappings
- document input robustness in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf4549a30833382c99ad80c85e20c